### PR TITLE
Make `Sham.t` not be opaque

### DIFF
--- a/lib/sham.ex
+++ b/lib/sham.ex
@@ -2,7 +2,9 @@ defmodule Sham do
   @derive {Inspect, only: [:port]}
   defstruct pid: nil, port: nil
 
-  @opaque t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          port: pos_integer()
+        }
 
   @moduledoc """
   Sham is a mock HTTP(S) server useful for testing HTTP(S) clients.


### PR DESCRIPTION
Ran into the following issue:

> Attempted to pattern match against the internal structure of an opaque term.
>
> Type:
> Sham.t()
>
> Pattern:
> %{:port => _port}
>
> This breaks the opaqueness of the term.

This happens in some setup code where I need to do the following:

```elixir
setup do
  sham = Sham.start()
  original = Application.get_env(:my_app, TheModule)
  Application.put_env(:my_app, TheModule, url: "http://localhost:#{sham.port}")
  on_exit(fn -> Application.put_env(:my_app, TheModule, original) end)
  {:ok, %{sham: sham}}
end
```

After changing from an opaque type to a normal type, it goes away.